### PR TITLE
Compatibility with MkDocs 1.5 change to extra_javascript

### DIFF
--- a/mkdocs_charts_plugin/plugin.py
+++ b/mkdocs_charts_plugin/plugin.py
@@ -15,7 +15,7 @@ CUSTOM_FENCES = [{"name": "vegalite", "class": "vegalite", "format": fence_vegal
 
 def check_library(libnames, dependency):
     for lib in libnames:
-        if dependency in lib:
+        if dependency in str(lib):
             return True
     raise PluginError(
         f"[mkdocs_charts_plugin]: Missing 'extra_javascript' dependency for {dependency}. Please see setup instructions."


### PR DESCRIPTION
Convert `extra_javascript` items to strings before treating them as paths, because they can now be `ExtraScriptValue` instead.

* Fixes #16

This is a bit of a [breaking change in MkDocs 1.5.0](https://www.mkdocs.org/about/release-notes/#script-tags-can-specify-typemodule-and-other-attributes). Sorry about the breakage.